### PR TITLE
Fix tag regex for the 'publish' workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Package
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - '^[0-9]+\.[0-9]+\.[0-9]+$'
 jobs:
   package:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #11

Minor fix that only affects the "release pipeline" part of the CI config.