### PR TITLE
Revert "Fix tag regex for the 'publish' workflow (#12)"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Package
 on:
   push:
     tags:
-      - '^[0-9]+\.[0-9]+\.[0-9]+$'
+      - '[0-9]+.[0-9]+.[0-9]+'
 jobs:
   package:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Turns out filtering in workflows isn't actually regex. Therefore #12 was wrong.

See: https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#patterns-to-match-branches-and-tags

Again, this is a minor fix that only affects the "release pipeline" part of the CI config.