### PR TITLE
Use extras_require[test] instead of tests_require

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,10 @@ install_requires =
   colcon-core
   coverage
 packages = find:
-tests_require =
+zip_safe = false
+
+[options.extras_require]
+test =
   flake8>=3.6.0
   flake8-blind-except
   flake8-builtins
@@ -47,7 +50,6 @@ tests_require =
   pytest
   pytest-cov
   scspell3k>=2.2
-zip_safe = false
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
This replaces `tests_require` with a pattern that seems to have popped up since pypa/setuptools#931 and pypa/setuptools#1684. It allows test dependencies to be installed by adding `[test]` to the end of the package name.