### PR TITLE
Add markers to linter tests, move linter imports

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,11 @@ exclude =
 colcon_core.verb =
   coveragepy-result = colcon_coveragepy_result.verb.coveragepy_result:CoveragePyResultVerb
 
+[tool:pytest]
+markers =
+  flake8
+  linter
+
 [flake8]
 import-order-style = google
 max-line-length = 99

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -6,6 +6,7 @@ cmake
 colcon
 coveragepy
 iterdir
+linter
 lstrip
 nargs
 noqa

--- a/test/test_copyright_license.py
+++ b/test/test_copyright_license.py
@@ -4,12 +4,12 @@
 from pathlib import Path
 import sys
 
+import pytest
 
+
+@pytest.mark.linter
 def test_copyright_license():
-    missing = check_files([
-        Path(__file__).parents[1],
-        Path(__file__).parents[1] / 'bin' / 'colcon',
-    ])
+    missing = check_files([Path(__file__).parents[1]])
     assert not len(missing), \
         'In some files no copyright / license line was found'
 

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -5,19 +5,20 @@ import logging
 from pathlib import Path
 import sys
 
-from flake8 import LOG
-from flake8.api.legacy import get_style_guide
-from pydocstyle.utils import log
+import pytest
 
 
-# avoid debug and info messages from flake8 internals
-LOG.setLevel(logging.WARNING)
-
-
+@pytest.mark.flake8
+@pytest.mark.linter
 def test_flake8():
+    from flake8.api.legacy import get_style_guide
+
+    # avoid debug / info / warning messages from flake8 internals
+    logging.getLogger('flake8').setLevel(logging.ERROR)
+
     # for some reason the pydocstyle logger changes to an effective level of 1
     # set higher level to prevent the output to be flooded with debug messages
-    log.setLevel(logging.WARNING)
+    logging.getLogger('pydocstyle').setLevel(logging.WARNING)
 
     style_guide = get_style_guide(
         extend_ignore=['D100', 'D104'],
@@ -48,9 +49,6 @@ def test_flake8():
         if report_tests.total_errors:
             report_tests._application.formatter.show_statistics(
                 report_tests._stats)
-        print(
-            'flake8 reported {total_errors} errors'
-            .format_map(locals()), file=sys.stderr)
+        print(f'flake8 reported {total_errors} errors', file=sys.stderr)
 
-    assert not total_errors, \
-        'flake8 reported {total_errors} errors'.format_map(locals())
+    assert not total_errors, f'flake8 reported {total_errors} errors'

--- a/test/test_spell_check.py
+++ b/test/test_spell_check.py
@@ -4,10 +4,6 @@
 from pathlib import Path
 
 import pytest
-from scspell import Report
-from scspell import SCSPELL_BUILTIN_DICT
-from scspell import spell_check
-
 
 spell_check_words_path = Path(__file__).parent / 'spell_check.words'
 
@@ -18,10 +14,16 @@ def known_words():
     return spell_check_words_path.read_text().splitlines()
 
 
+@pytest.mark.linter
 def test_spell_check(known_words):
-    source_filenames = [
-        Path(__file__).parents[1] / 'setup.py'] + \
-        list((Path(__file__).parents[1] / 'colcon_coveragepy_result').glob('**/*.py')) + \
+    from scspell import Report
+    from scspell import SCSPELL_BUILTIN_DICT
+    from scspell import spell_check
+
+    source_filenames = [Path(__file__).parents[1] / 'setup.py'] + \
+        list(
+            (Path(__file__).parents[1] / 'colcon_coveragepy_result')
+            .glob('**/*.py')) + \
         list((Path(__file__).parents[1] / 'test').glob('**/*.py'))
 
     for source_filename in sorted(source_filenames):
@@ -35,21 +37,23 @@ def test_spell_check(known_words):
 
     unknown_word_count = len(report.unknown_words)
     assert unknown_word_count == 0, \
-        'Found {unknown_word_count} unknown words: '.format_map(locals()) + \
+        f'Found {unknown_word_count} unknown words: ' + \
         ', '.join(sorted(report.unknown_words))
 
     unused_known_words = set(known_words) - report.found_known_words
     unused_known_word_count = len(unused_known_words)
     assert unused_known_word_count == 0, \
-        '{unused_known_word_count} words in the word list are not used: ' \
-        .format_map(locals()) + ', '.join(sorted(unused_known_words))
+        f'{unused_known_word_count} words in the word list are not used: ' + \
+        ', '.join(sorted(unused_known_words))
 
 
+@pytest.mark.linter
 def test_spell_check_word_list_order(known_words):
     assert known_words == sorted(known_words), \
         'The word list should be ordered alphabetically'
 
 
+@pytest.mark.linter
 def test_spell_check_word_list_duplicates(known_words):
     assert len(known_words) == len(set(known_words)), \
         'The word list should not contain duplicates'


### PR DESCRIPTION
Test markers can be used to easily (de-)select tests, and colcon exposes mechanisms to do so. Linters are a category of tests that are commonly called out.

Additionally, if we move the imports for some of our single-purpose tests into the test function, we can avoid installing the linter dependencies entirely. This is a common case in platform packaging, where linter errors are not actionable and the dependencies are not typically installed.